### PR TITLE
updated dependencies of lo_frontend

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,13 @@ LOCUS (Lidar Odometry for Consistent operation in Uncertain Settings) is a Multi
 
 ![alt text](readme.png)
 
+# Prerequisites
+
+`tf2_sensor_msgs` may not be installed by default, so install with:
+```
+sudo apt install ros-$(rosversion -d)-tf2-sensor-msgs
+```
+
 # TODOS
 
 - [ ] Rename all lo_frontend instances to locus

--- a/lo_frontend/CMakeLists.txt
+++ b/lo_frontend/CMakeLists.txt
@@ -36,10 +36,19 @@ find_package(catkin REQUIRED COMPONENTS
   pcl_ros
   pcl_conversions
   core_msgs
+  diagnostic_msgs
   geometry_msgs
   nav_msgs
+  sensor_msgs
+  std_msgs
+  visualization_msgs
   message_generation
   frontend_utils
+  tf
+  tf2_ros
+  tf2_geometry_msgs
+  tf2_sensor_msgs
+  dynamic_reconfigure
 )
 
 find_package(OpenMP)
@@ -65,9 +74,20 @@ catkin_package(
     pcl_ros
     pcl_conversions
     core_msgs
+    diagnostic_msgs
     geometry_msgs
     nav_msgs
+    sensor_msgs
+    std_msgs
+    visualization_msgs
     frontend_utils
+    tf
+    tf2
+    tf2_ros
+    tf2_geometry_msgs
+    tf2_sensor_msgs
+    dynamic_reconfigure
+    message_filters
   DEPENDS
     Boost
 )

--- a/lo_frontend/package.xml
+++ b/lo_frontend/package.xml
@@ -23,9 +23,20 @@
   <build_depend>pcl_ros</build_depend>
   <build_depend>pcl_conversions</build_depend>
   <build_depend>core_msgs</build_depend>
+  <build_depend>diagnostic_msgs</build_depend>
   <build_depend>geometry_msgs</build_depend>
   <build_depend>nav_msgs</build_depend>
+  <build_depend>sensor_msgs</build_depend>
+  <build_depend>std_msgs</build_depend>
+  <build_depend>visualization_msgs</build_depend>
   <build_depend>frontend_utils</build_depend>
+  <build_depend>tf</build_depend>
+  <build_depend>tf2</build_depend>
+  <build_depend>tf2_ros</build_depend>
+  <build_depend>tf2_geometry_msgs</build_depend>
+  <build_depend>tf2_sensor_msgs</build_depend>
+  <build_depend>dynamic_reconfigure</build_depend>
+  <build_depend>message_filters</build_depend>
 
   <run_depend>roscpp</run_depend>
   <run_depend>message_runtime</run_depend>
@@ -40,9 +51,20 @@
   <run_depend>pcl_ros</run_depend>
   <run_depend>pcl_conversions</run_depend>
   <run_depend>core_msgs</run_depend>
+  <run_depend>diagnostic_msgs</run_depend>
   <run_depend>geometry_msgs</run_depend>
   <run_depend>nav_msgs</run_depend>
+  <run_depend>sensor_msgs</run_depend>
+  <run_depend>std_msgs</run_depend>
+  <run_depend>visualization_msgs</run_depend>
   <run_depend>frontend_utils</run_depend>
+  <run_depend>tf</run_depend>
+  <run_depend>tf2</run_depend>
+  <run_depend>tf2_ros</run_depend>
+  <run_depend>tf2_geometry_msgs</run_depend>
+  <run_depend>tf2_sensor_msgs</run_depend>
+  <run_depend>dynamic_reconfigure</run_depend>
+  <run_depend>message_filters</run_depend>
 
   <test_depend>rostest</test_depend>
   <test_depend>rosunit</test_depend>  


### PR DESCRIPTION
I noticed there were some dependencies missing in `lo_frontend`. In particular, `tf2_sensor_msgs` was not installed on my system (noetic) by default, so added a comment to the README. I think the rest do come with a standard ROS install.