### PR TITLE
removed hard-coded vn100 imu frame id check

### DIFF
--- a/lo_frontend/src/LoFrontend.cc
+++ b/lo_frontend/src/LoFrontend.cc
@@ -700,7 +700,7 @@ void LoFrontend::CheckImuFrame(const ImuConstPtr& imu_msg)
 {
   if (b_convert_imu_to_base_link_frame_)
   {
-    if (imu_msg->header.frame_id.find("vn100") != std::string::npos)
+    if (imu_msg->header.frame_id == imu_frame_id_)
     {
       ROS_INFO("Received imu_msg is correctly expressed in imu frame");
       b_imu_frame_is_correct_ = true;


### PR DESCRIPTION
Attempting to use the imu to base link conversion is problematic for a new platform since the "vn100" is hard-coded into the IMU frame check.

While I think the change is correct (the imu to base link frame id look up uses `imu_frame_id_`), there is a chance this change may break some LOCUS datasets if the frame_id in the imu messages is "vn100" instead of "<robot_name>/vn100" which it should be.