### PR TITLE
Fix build issues for point_cloud_filter package

### DIFF
--- a/point_cloud_filter/CMakeLists.txt
+++ b/point_cloud_filter/CMakeLists.txt
@@ -63,3 +63,6 @@ target_link_libraries(${PROJECT_NAME}_node
   ${PROJECT_NAME}
   ${catkin_LIBRARIES}
 )
+
+# add dependencies to the dynamic reconfigure files
+add_dependencies(${PROJECT_NAME} ${PROJECT_NAME}_gencfg)


### PR DESCRIPTION
Fixes the build issues mentioned in #57, by adding the generated config files as dependencies in the CMakeLists.txt file for the point_cloud_filter package. 
Tested on ROS noetic and ROS melodic.